### PR TITLE
docs: Note first draft deadline updated to 2024-06-07

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ SciPy 2024 Proceedings PR: https://github.com/scipy-conference/scipy_proceedings
 
 | Date | Event | Passed (✅/❌) |
 | -    | :-    | -              |
-| May 31   | Deadline to submit first draft by authors | 🎯 |
-| May 31   | Open Review Period begins                 |  |
+| June 7   | Deadline to submit first draft by authors | 🎯 |
+| June 7   | Open Review Period begins                 |  |
 | June 21  | Initial complete review                   |  |
 | July 26  | Final review deadline                     |  |
 | July 31  | Final author revision deadline            |  |


### PR DESCRIPTION
> Dear Matthew Feickert,
>
> We are writing to inform you that the paper submission deadline has been moved back one week, to Friday, June 7th, 2024.
>
> Submitting a full paper is not required to present at the conference, but if you choose to write one, your full paper must be submitted as a pull request via GitHub by June 7th, 2024. Further instructions can be found here:
> https://github.com/scipy-conference/scipy_proceedings/blob/2024/README.md#instructions-for-authors
>
> A webinar with walkthrough and Q&A on how to submit to the proceedings was offered on May 3rd, 2024. A recording of the webinar can be found here:
> https://www.youtube.com/watch?v=v97nJOCAWHI
>
> After the conference, you will have the opportunity to submit electronic copies of your poster or talk slides for archiving with SciPy. Further information about submitting slides and posters can be found here:
> https://github.com/scipy-conference/scipy_proceedings/blob/2024/README.md#instructions-for-slides
>
> Finally, if you have already submitted a paper, thank you! We very much look forward to reading your submissions alongside our volunteer reviewers during the coming weeks.
>
> Yours,
> The SciPy 2024 Proceedings Committee