### PR TITLE
fix: Use 'Evangelos Kourlitis' as this is publishing name

### DIFF
--- a/paper/myst.yml
+++ b/paper/myst.yml
@@ -27,7 +27,7 @@ project:
       orcid: 0000-0002-8924-5885
       affiliations:
         - University of Wisconsin--Madison
-    - name: Vangelis Kourlitis
+    - name: Evangelos Kourlitis
       email: evangelos.kourlitis@cern.ch
       orcid: 0000-0001-6568-2047
       affiliations:


### PR DESCRIPTION
* In publications, Evangelos, the full first name, is used.