### PR TITLE
docs: Add citation for IRIS-HEP AGC

### DIFF
--- a/paper/mybib.bib
+++ b/paper/mybib.bib
@@ -342,6 +342,35 @@ url = {https://github.com/scikit-hep/iminuit}
   doi          = "10.7483/OPENDATA.ATLAS.2Y1T.TLGL",
 }
 
+# IRIS-HEP Analysis Grand Challenge ATLAS
+@misc{IRIS-HEP-AGC,
+  author       = {Alexander Held and
+                  Elliott Kauffman and
+                  Oksana Shadura and
+                  Enrico Guiraud and
+                  Matthew Feickert and
+                  Jayjeet Chakraborty and
+                  Mason Proffitt and
+                  Andrew Wightman and
+                  KyungEon Choi and
+                  Andrzej Novak and
+                  David Koch and
+                  Elise Chavez and
+                  Maria A. and
+                  Mat Adamec and
+                  Saransh Chopra and
+                  Storm Lin and
+                  Tal van Daalen and
+                  TatianaOvsiannikova},
+  title        = "IRIS-HEP Analysis Grand Challenge",
+  month        = sep,
+  year         = 2023,
+  publisher    = {Zenodo},
+  version      = {v1.4.0},
+  doi          = {10.5281/zenodo.7274936},
+  url          = {https://doi.org/10.5281/zenodo.7274936}
+}
+
 # These references may be helpful:
 
 @inproceedings{jupyter,

--- a/paper/uncovering-higgs.md
+++ b/paper/uncovering-higgs.md
@@ -14,7 +14,7 @@ We need to stick only to the Z->ee decay if we want to use the python-ported EGa
 
 The most famous and revolutionary discovery in particle physics this century is the discovery of the Higgs boson &mdash; the particle corresponding to the quantum field that gives mass to fundamental particles through the Brout-Englert-Higgs mechanism &mdash; by the ATLAS and CMS experimental collaborations in 2012. [@HIGG-2012-27;@CMS-HIG-12-028]
 This discovery work was done using large amounts of customized `C++` software, but in the following decade the state of the PyHEP community has advanced enough that the workflow can now be done using community Python tooling.
-To provide an overview of the Pythonic tooling and functionality, a high level summary of a simplified analysis workflow of a Higgs "decay" to two intermediate $Z$ bosons that decay to charged leptons $(\ell)$ (i.e. electrons ($e$) and muons ($\mu$)), $H \to Z Z^{*} \to 4 \ell$, on ATLAS open data [@ATLAS-open-data] is summarized in this section.
+To provide an overview of the Pythonic tooling and functionality, a high level summary of a simplified analysis workflow [@IRIS-HEP-AGC] of a Higgs "decay" to two intermediate $Z$ bosons that decay to charged leptons $(\ell)$ (i.e. electrons ($e$) and muons ($\mu$)), $H \to Z Z^{*} \to 4 \ell$, on ATLAS open data [@ATLAS-open-data] is summarized in this section.
 
 ### Loading data
 


### PR DESCRIPTION
* Add citation to Zenodo archive for AGC.
   - c.f. https://doi.org/10.5281/zenodo.7274936